### PR TITLE
Change casening of PluginInfo key

### DIFF
--- a/class.oembed.plugin.php
+++ b/class.oembed.plugin.php
@@ -1,6 +1,6 @@
 <?php if (!defined('APPLICATION')) exit;
 
-$PluginInfo['oembed'] = array(
+$PluginInfo['OEmbed'] = array(
     'Name'        => "OEmbed",
     'Description' => "OEmbed enables you to embed content from a myriad of different providers",
     'Version'     => '2.0.1',


### PR DESCRIPTION
When PluginInfo key is not exactly the same as in the class name, there can be problems when someone tries to disable it. (http://vanillaforums.org/discussion/30217/manually-disable-plugin#latest)